### PR TITLE
Adds option for 'large poster' which will allow users to set a larger resolution poster image for tiles

### DIFF
--- a/backend/schemas/dashboardTile.js
+++ b/backend/schemas/dashboardTile.js
@@ -5,6 +5,7 @@ var tiles = mongoose.Schema({
     "displayTitle": String,
     "description": String,
     "_poster": String,
+    "_largePoster": String,
     "_linkType": {type: String, default: 'externalLink'},
     "_courseLink": {type: mongoose.Schema.Types.ObjectId, ref:'Course'},
     "_resourceUpload": String,

--- a/backend/schemas/editDashboardTiles.js
+++ b/backend/schemas/editDashboardTiles.js
@@ -74,7 +74,13 @@ module.exports = {
                     },
                     "_poster": {
                         "type": "AssetUpload:Image:Small",
-                        "label": "Poster Image"
+                        "label": "Small poster image",
+                        "help": "Best used when the number of tiles per row is set to 2 or 3, we would recommend an image around 500px wide"
+                    },
+                    "_largePoster": {
+                        "type": "AssetUpload:Image:Large",
+                        "label": "Large poster image",
+                        "help": "Best used when the number of tiles per row is set to 1, we would recommend an image around 950px wide"
                     },
                     "_linkType": {
                         "type": "Select",

--- a/frontend/components/dashboardTile.js
+++ b/frontend/components/dashboardTile.js
@@ -6,7 +6,13 @@ import getSlugOrId from 'helpers/getSlugOrId';
 var DashboardTile = createReactClass({
 
     getGraphicStyle: function() {
-        var backgroundImage = 'url("' + this.props.tile._poster + '")';
+        var posterUrl = this.props.tile._poster || this.props.tile._largePoster;
+
+        if (this.props.tilesPerRow === 1 && this.props.tile._largePoster) {
+            posterUrl = this.props.tile._largePoster;
+        }
+            
+        var backgroundImage = 'url("' + posterUrl + '")';
 
         return {
             backgroundImage: backgroundImage
@@ -31,7 +37,7 @@ var DashboardTile = createReactClass({
     },
 
     renderGraphic: function() {
-        if (this.props.tile._poster) {
+        if (this.props.tile._poster || this.props.tile._largePoster) {
             return (
                 <div
                     className="dashboard-tiles-tile-graphic"


### PR DESCRIPTION
Adds check in to see which type of poster is being used, then if the number of tiles per row is set to 1 it will prefer the large poster. It will use either but prefer the smaller regardless of the number of tiles per row.

Fixes #18 and https://github.com/appitierre/bloomPlatform/issues/2145